### PR TITLE
Update order of value files to ensure generated file will take precedence

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,12 +191,12 @@ async function run() {
       "--wait",
       "--atomic",
       `--namespace=${namespace}`,
-      "--values=./values.yml",
     ];
     if (dryRun) args.push("--dry-run");
     if (appName) args.push(`--set=app.name=${appName}`);
     if (version) args.push(`--set=app.version=${version}`);
     valueFiles.forEach(f => args.push(`--values=${f}`));
+    args.push("--values=./values.yml");
 
     // Special behaviour is triggered if the track is labelled 'canary'. The
     // service and ingress resources are disabled. Access to the canary


### PR DESCRIPTION
This PR fixes https://github.com/deliverybot/helm/issues/12. It simply places the `--values=./values.yml` argument at the very last place in the whole command. This ensures the values inside this file will take precedence over their previous definitions (like defaults), since order of value file declaration apparently matters. 