### PR TITLE
[WIP] add parameter for chart version, add repository parameter, add helm home

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ payload if the action was triggered by a deployment.
 - `namespace`: Kubernetes namespace name. (required)
 - `chart`: Helm chart path. If set to "app" this will use the built in helm
   chart found in this repository. (required)
+- `chart_version`: The version of the helm chart you want to deploy (distinct from app version)
 - `values`: Helm chart values, expected to be a YAML or JSON string.
 - `track`: Track for the deployment. If the track is not "stable" it activates
   the canary workflow described below.
@@ -33,6 +34,7 @@ payload if the action was triggered by a deployment.
 - `helm`: Helm binary to execute, one of: [`helm`, `helm3`].
 - `version`: Version of the app, usually commit sha works here.
 - `timeout`: specify a timeout for helm deployment
+- `repository`: specify the URL for a helm repo to come from
 
 Additional parameters: If the action is being triggered by a deployment event
 and the `task` parameter in the deployment event is set to `"remove"` then this

--- a/index.js
+++ b/index.js
@@ -158,6 +158,7 @@ async function run() {
     const release = releaseName(appName, track);
     const namespace = getInput("namespace", required);
     const chart = chartName(getInput("chart", required));
+    const chartVersion = getInput("chart_version");
     const values = getValues(getInput("values"));
     const task = getInput("task");
     const version = getInput("version");
@@ -165,7 +166,7 @@ async function run() {
     const removeCanary = getInput("remove_canary");
     const helm = getInput("helm") || "helm";
     const timeout = getInput("timeout");
-
+    const repository = getInput("repository");
     const dryRun = core.getInput("dry-run");
     const secrets = getSecrets(core.getInput("secrets"));
 
@@ -174,6 +175,7 @@ async function run() {
     core.debug(`param: appName = "${appName}"`);
     core.debug(`param: namespace = "${namespace}"`);
     core.debug(`param: chart = "${chart}"`);
+    core.debug(`param: chart_version = "${chartVersion}"`);
     core.debug(`param: values = "${values}"`);
     core.debug(`param: dryRun = "${dryRun}"`);
     core.debug(`param: task = "${task}"`);
@@ -182,6 +184,8 @@ async function run() {
     core.debug(`param: valueFiles = "${JSON.stringify(valueFiles)}"`);
     core.debug(`param: removeCanary = ${removeCanary}`);
     core.debug(`param: timeout = "${timeout}"`);
+    core.debug(`param: repository = "${repository}"`);
+
 
     // Setup command options and arguments.
     const opts = { env: {
@@ -195,11 +199,15 @@ async function run() {
       "--wait",
       "--atomic",
       `--namespace=${namespace}`,
+      '--home=/root/.helm/',
     ];
+
     if (dryRun) args.push("--dry-run");
     if (appName) args.push(`--set=app.name=${appName}`);
     if (version) args.push(`--set=app.version=${version}`);
+    if (chartVersion) args.push(`--version=${chartVersion}`);
     if (timeout) args.push(`--timeout=${timeout}`);
+    if (repository) args.push(`--repo=${repository}`);
     valueFiles.forEach(f => args.push(`--values=${f}`));
     args.push("--values=./values.yml");
 


### PR DESCRIPTION
This might be 2 issues in one PR but it seems trivial not to separate them.

Initially this should fix: #21 for @raj-shekhar1 , in getting this to work it was necessary to hardcode the helm home argument in the install command (to where docker will install helm to) i'm not entirely happy with this so am open to comments on a better solution (this is fixed in helm3 i believe but shouldn't hurt)

also we need to specify which chart version should be installed  which is different to the application version. So i have added this parameter in what should be a backwards compatible manner