### PR TITLE
Add support for EKS clusters and fix helm v3 home issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ENV BASE_URL="https://get.helm.sh"
 ENV HELM_2_FILE="helm-v2.16.1-linux-amd64.tar.gz"
 ENV HELM_3_FILE="helm-v3.0.0-linux-amd64.tar.gz"
 
-RUN apk add --no-cache ca-certificates jq curl bash nodejs && \
+RUN apk add --no-cache ca-certificates \
+    --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
+    jq curl bash nodejs aws-cli && \
     # Install helm version 2:
     curl -L ${BASE_URL}/${HELM_2_FILE} |tar xvz && \
     mv linux-amd64/helm /usr/bin/helm && \
@@ -18,6 +20,8 @@ RUN apk add --no-cache ca-certificates jq curl bash nodejs && \
     rm -rf linux-amd64 && \
     # Init version 2 helm:
     helm init --client-only
+
+ENV PYTHONPATH "/usr/lib/python3.8/site-packages/"
 
 COPY . /usr/src/
 ENTRYPOINT ["node", "/usr/src/index.js"]

--- a/index.js
+++ b/index.js
@@ -196,8 +196,16 @@ async function run() {
       "--wait",
       "--atomic",
       `--namespace=${namespace}`,
-      '--home=/root/.helm/',
     ];
+
+    // Per https://helm.sh/docs/faq/#xdg-base-directory-support
+    if (helm === "helm3") {
+      process.env.XDG_DATA_HOME = "/root/.helm/"
+      process.env.XDG_CACHE_HOME = "/root/.helm/"
+      process.env.XDG_CONFIG_HOME = "/root/.helm/"
+    } else {
+      process.env.HELM_HOME = "/root/.helm/"
+    }
 
     if (dryRun) args.push("--dry-run");
     if (appName) args.push(`--set=app.name=${appName}`);

--- a/index.js
+++ b/index.js
@@ -188,9 +188,6 @@ async function run() {
 
 
     // Setup command options and arguments.
-    const opts = { env: {
-      KUBECONFIG: process.env.KUBECONFIG,
-    }};
     const args = [
       "upgrade",
       release,
@@ -220,12 +217,12 @@ async function run() {
 
     // Setup necessary files.
     if (process.env.KUBECONFIG_FILE) {
-      opts.env.KUBECONFIG = "./kubeconfig.yml";
-      await writeFile(opts.env.KUBECONFIG, process.env.KUBECONFIG_FILE);
+      process.env.KUBECONFIG = "./kubeconfig.yml";
+      await writeFile(process.env.KUBECONFIG, process.env.KUBECONFIG_FILE);
     }
     await writeFile("./values.yml", values);
 
-    core.debug(`env: KUBECONFIG="${opts.env.KUBECONFIG}"`);
+    core.debug(`env: KUBECONFIG="${process.env.KUBECONFIG}"`);
 
     // Render value files using github variables.
     await renderFiles(valueFiles.concat(["./values.yml"]), {
@@ -237,7 +234,6 @@ async function run() {
     if (removeCanary) {
       core.debug(`removing canary ${appName}-canary`);
       await exec.exec(helm, deleteCmd(helm, namespace, `${appName}-canary`), {
-        ...opts,
         ignoreReturnCode: true
       });
     }
@@ -245,11 +241,10 @@ async function run() {
     // Actually execute the deployment here.
     if (task === "remove") {
       await exec.exec(helm, deleteCmd(helm, namespace, release), {
-        ...opts,
         ignoreReturnCode: true
       });
     } else {
-      await exec.exec(helm, args, opts);
+      await exec.exec(helm, args);
     }
 
     await status(task === "remove" ? "inactive" : "success");


### PR DESCRIPTION
As discussed in #22, the `kubeconfig` for an EKS cluster relies on having the `aws` CLI available. This PR adds the `aws-cli` dependency and configure the PYTHONPATH so the `aws` command can find its modules. 

Passing `opts` was not necessary as github `exec` is by default passing all environment variables to the child process: https://github.com/actions/toolkit/blob/master/packages/exec/src/interfaces.ts#L9

I also addressed an issue with `helm3` introduced by adding the `--home-path`. I switched to using environment variables as suggested on Helm guides: https://helm.sh/docs/faq/#xdg-base-directory-support.

