### PR TITLE
Add missing `helm` input parameter to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,8 @@ inputs:
   dry-run:
     description: Task name. If the task is "remove" it will remove the configured
       helm release.
+  helm:
+    description: Helm binary to execute, one of: [helm, helm3].
   token:
     description: Github repository token. If included and the event is a deployment
       the deployment_status event will be fired.


### PR DESCRIPTION
The parameter is in the documentation and is used inside the actual action file, however it is missing in the action.yml which causes a warning in the log. Fixes #28 