### PR TITLE
feat: add optional KUBECONFIG_BASE64 env to pass base64-encoded value

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,6 +146,15 @@ function deleteCmd(helm, namespace, release) {
 }
 
 /**
+ * Takes in a secret value and decodes it from base64.
+ *
+ * @param {string} secretVal
+ */
+function parseBase64(secretVal) {
+  return Buffer.from(secretVal, 'base64').toString('utf-8');
+}
+
+/**
  * Run executes the helm deployment.
  */
 async function run() {
@@ -227,6 +236,9 @@ async function run() {
     if (process.env.KUBECONFIG_FILE) {
       process.env.KUBECONFIG = "./kubeconfig.yml";
       await writeFile(process.env.KUBECONFIG, process.env.KUBECONFIG_FILE);
+    } else if (process.env.KUBECONFIG_BASE64) {
+      process.env.KUBECONFIG = "./kubeconfig.yml";
+      await writeFile(process.env.KUBECONFIG, parseBase64(process.env.KUBECONFIG_BASE64));
     }
     await writeFile("./values.yml", values);
 


### PR DESCRIPTION
Changes:
- Added a `parseBase64` function to decode base64 secret value of **KUBECONFIG_BASE64** env
- If the user hasn't set **KUBECONFIG_FILE** env, then try to decode **KUBECONFIG_BASE64** env value.

Motivation:
- To make our workflow compliant with other github actions, we stored base64-encoded value of kubeconfig.
- Decoding it in a previous step and setting is as env or output of step doesn't work since GitHub Actions [truncates multi-line strings](https://github.com/actions/toolkit/issues/403).
- Decoding the secret from base64 and then encoding it to Github Actions compliant string didn't work since now Helm cannot parse the yaml.