### PR TITLE
Made the atomic option configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ payload if the action was triggered by a deployment.
 - `version`: Version of the app, usually commit sha works here.
 - `timeout`: specify a timeout for helm deployment
 - `repository`: specify the URL for a helm repo to come from
+- `atomic`: If true, upgrade process rolls back changes made in case of failed upgrade. Defaults to true.
 
 Additional parameters: If the action is being triggered by a deployment event
 and the `task` parameter in the deployment event is set to `"remove"` then this

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,15 @@ inputs:
   values:
     description: Helm chart values, expected to be a YAML or JSON string.
     required: false
-  dry-run:
+  task:
     description: Task name. If the task is "remove" it will remove the configured
       helm release.
+    required: false
+  dry-run:
+    description: Simulate an upgrade.
+    required: false
+  atomic:
+    description: If true, upgrade process rolls back changes made in case of failed upgrade. Defaults to true.
     required: false
   helm:
     description: Helm binary to execute, one of [helm, helm3].

--- a/index.js
+++ b/index.js
@@ -169,6 +169,7 @@ async function run() {
     const repository = getInput("repository");
     const dryRun = core.getInput("dry-run");
     const secrets = getSecrets(core.getInput("secrets"));
+    const atomic = getInput("atomic") || true;
 
     core.debug(`param: track = "${track}"`);
     core.debug(`param: release = "${release}"`);
@@ -185,6 +186,7 @@ async function run() {
     core.debug(`param: removeCanary = ${removeCanary}`);
     core.debug(`param: timeout = "${timeout}"`);
     core.debug(`param: repository = "${repository}"`);
+    core.debug(`param: atomic = "${atomic}"`);
 
 
     // Setup command options and arguments.
@@ -194,7 +196,6 @@ async function run() {
       chart,
       "--install",
       "--wait",
-      "--atomic",
       `--namespace=${namespace}`,
     ];
 
@@ -221,6 +222,11 @@ async function run() {
     // deployments can be routed via the main stable service resource.
     if (track === "canary") {
       args.push("--set=service.enabled=false", "--set=ingress.enabled=false");
+    }
+
+    // If true upgrade process rolls back changes made in case of failed upgrade.
+    if (atomic === true) {
+      args.push("--atomic");
     }
 
     // Setup necessary files.


### PR DESCRIPTION
In our case not every deployment should be rolled back when the deployment fails. For example, our test environment requires additional debugging when the deployment fails. In my opinion the atomic setting should only be used on acceptance/production environments.

To be backwards compatible I've set the default to true for the atomic setting, if requested I can change this.