### PR TITLE
Bump helm3 binary to current latest 3.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.10.2
 ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
-ENV HELM_3_FILE="helm-v3.4.2-linux-amd64.tar.gz"
+ENV HELM_3_FILE="helm-v3.5.2-linux-amd64.tar.gz"
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ action will execute a `helm delete $service`
 #### Versions
 
 - `helm`: v2.16.1
-- `helm3`: v3.0.0
+- `helm3`: v3.5.2
 
 ### Environment
 


### PR DESCRIPTION
https://github.com/helm/helm/releases/tag/v3.5.2
Bump from 3.4.2 -> 3.5.2