### PR TITLE
Upgrade `helm-deploy` action Dockerfile to Node.js 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV HELM_3_FILE="helm-v3.4.2-linux-amd64.tar.gz"
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
     jq curl bash nodejs aws-cli && \
+    pip3 install awscli && \
     # Install helm version 2:
     curl -L ${BASE_URL}/${HELM_2_FILE} |tar xvz && \
     mv linux-amd64/helm /usr/bin/helm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.10.2
+FROM alpine:3.14.0
 
 ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
-ENV HELM_3_FILE="helm-v3.4.2-linux-amd64.tar.gz"
+ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.14.0
 
 ENV BASE_URL="https://get.helm.sh"
 
-ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
+#ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
 ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
 
 RUN apk add --no-cache ca-certificates \
@@ -12,17 +12,17 @@ RUN apk add --no-cache ca-certificates \
     pip3 install awscli
 RUN \
     # Install helm version 2:
-    curl -L ${BASE_URL}/${HELM_2_FILE} |tar xvz && \
-    mv linux-amd64/helm /usr/bin/helm && \
-    chmod +x /usr/bin/helm && \
-    rm -rf linux-amd64 && \
+    # curl -L ${BASE_URL}/${HELM_2_FILE} |tar xvz && \
+    # mv linux-amd64/helm /usr/bin/helm && \
+    # chmod +x /usr/bin/helm && \
+    # rm -rf linux-amd64 && \
     # Install helm version 3:
     curl -L ${BASE_URL}/${HELM_3_FILE} |tar xvz && \
     mv linux-amd64/helm /usr/bin/helm3 && \
     chmod +x /usr/bin/helm3 && \
     rm -rf linux-amd64 && \
     # Init version 2 helm:
-    helm init --client-only && \
+    helm3 init --client-only && \
     # install helm s3 plugin
     helm3 plugin install https://github.com/hypnoglow/helm-s3.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,14 @@ ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
 ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
-
+# make sure these variables are the same in index.js as Gitgub can change the user home
+ENV HELM_CACHE_HOME="/root/.cache/helm"
+ENV HELM_CONFIG_HOME="/root/.config/helm"
+ENV HELM_DATA_HOME="/root/.local/share/helm"
+ENV HELM_PLUGINS="/root/.local/share/helm/plugins"
+ENV HELM_REGISTRY_CONFIG="/root/.config/helm/registry.json"
+ENV HELM_REPOSITORY_CACHE="/root/.cache/helm/repository"
+ENV HELM_REPOSITORY_CONFIG="/root/.config/helm/repositories.yaml"
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
     jq curl bash nodejs aws-cli py3-setuptools &&\
-    apk add py3-pip && \
+    apk add py3-pip git && \
     pip3 install awscli
 RUN \
     # Install helm version 2:
@@ -22,7 +22,10 @@ RUN \
     chmod +x /usr/bin/helm3 && \
     rm -rf linux-amd64 && \
     # Init version 2 helm:
-    helm init --client-only
+    helm init --client-only && \
+    # install helm s3 plugin
+    helm3 plugin install https://github.com/hypnoglow/helm-s3.git
+
 
 ENV PYTHONPATH "/usr/lib/python3.8/site-packages/"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     # Init version 2 helm:
     helm init --client-only && \
     # install helm s3 plugin
-    helm3 plugin install https://github.com/hypnoglow/helm-s3.git
+    helm3 plugin install https://github.com/hypnoglow/helm-s3 --version v0.16.2
 
 
 ENV PYTHONPATH "/usr/lib/python3.8/site-packages/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.14.0
 
 ENV BASE_URL="https://get.helm.sh"
 
-#ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
+ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
 ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
 
 RUN apk add --no-cache ca-certificates \
@@ -12,17 +12,17 @@ RUN apk add --no-cache ca-certificates \
     pip3 install awscli
 RUN \
     # Install helm version 2:
-    # curl -L ${BASE_URL}/${HELM_2_FILE} |tar xvz && \
-    # mv linux-amd64/helm /usr/bin/helm && \
-    # chmod +x /usr/bin/helm && \
-    # rm -rf linux-amd64 && \
+    curl -L ${BASE_URL}/${HELM_2_FILE} |tar xvz && \
+    mv linux-amd64/helm /usr/bin/helm && \
+    chmod +x /usr/bin/helm && \
+    rm -rf linux-amd64 && \
     # Install helm version 3:
     curl -L ${BASE_URL}/${HELM_3_FILE} |tar xvz && \
     mv linux-amd64/helm /usr/bin/helm3 && \
     chmod +x /usr/bin/helm3 && \
     rm -rf linux-amd64 && \
     # Init version 2 helm:
-    #helm3 init --client-only && \
+    helm init --client-only && \
     # install helm s3 plugin
     helm3 plugin install https://github.com/hypnoglow/helm-s3.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN \
     # Init version 2 helm:
     helm init --client-only && \
     # install helm s3 plugin
-    helm3 plugin install https://github.com/hypnoglow/helm-s3.git
+    #helm3 plugin install https://github.com/hypnoglow/helm-s3.git
 
 
 ENV PYTHONPATH "/usr/lib/python3.8/site-packages/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14.0
 ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
-ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
+ENV HELM_3_FILE="helm-v3.16.3-linux-amd64.tar.gz"
 # make sure these variables are the same in index.js as Gitgub can change the user home
 ENV HELM_CACHE_HOME="/root/.cache/helm"
 ENV HELM_CONFIG_HOME="/root/.config/helm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN \
     chmod +x /usr/bin/helm3 && \
     rm -rf linux-amd64 && \
     # Init version 2 helm:
-    helm init --client-only && \
+    helm init --client-only
+    #&& \
     # install helm s3 plugin
     #helm3 plugin install https://github.com/hypnoglow/helm-s3.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,7 @@ ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
 ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
-ENV HELM_CACHE_HOME="/github/home/.cache/helm"
-ENV HELM_CONFIG_HOME="/github/home/.config/helm"
-ENV HELM_DATA_HOME="/github/home/.local/share/helm"
-ENV HELM_PLUGINS="/github/home/.local/share/helm/plugins"
-ENV HELM_REGISTRY_CONFIG="/github/home/.config/helm/registry.json"
-ENV HELM_REPOSITORY_CACHE="/github/home/.cache/helm/repository"
-ENV HELM_REPOSITORY_CONFIG="/github/home/.config/helm/repositories.yaml"
+
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
-    jq curl bash nodejs aws-cli && \
-    pip3 install awscli && \
+    jq curl bash nodejs aws-cli py3-setuptools &&\
+    apk add py3-pip && \
+    pip3 install awscli
+RUN \
     # Install helm version 2:
     curl -L ${BASE_URL}/${HELM_2_FILE} |tar xvz && \
     mv linux-amd64/helm /usr/bin/helm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
     chmod +x /usr/bin/helm3 && \
     rm -rf linux-amd64 && \
     # Init version 2 helm:
-    helm3 init --client-only && \
+    #helm3 init --client-only && \
     # install helm s3 plugin
     helm3 plugin install https://github.com/hypnoglow/helm-s3.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14.0
 ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
-ENV HELM_3_FILE="helm-v3.14.0-linux-amd64.tar.gz"
+ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
@@ -22,10 +22,9 @@ RUN \
     chmod +x /usr/bin/helm3 && \
     rm -rf linux-amd64 && \
     # Init version 2 helm:
-    helm init --client-only
-    #&& \
+    helm init --client-only && \
     # install helm s3 plugin
-    #helm3 plugin install https://github.com/hypnoglow/helm-s3.git
+    helm3 plugin install https://github.com/hypnoglow/helm-s3.git
 
 
 ENV PYTHONPATH "/usr/lib/python3.8/site-packages/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
 ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
+ENV HELM_CACHE_HOME="/github/home/.cache/helm"
+ENV HELM_CONFIG_HOME="/github/home/.config/helm"
+ENV HELM_DATA_HOME="/github/home/.local/share/helm"
+ENV HELM_PLUGINS="/github/home/.local/share/helm/plugins"
+ENV HELM_REGISTRY_CONFIG="/github/home/.config/helm/registry.json"
+ENV HELM_REPOSITORY_CACHE="/github/home/.cache/helm/repository"
+ENV HELM_REPOSITORY_CONFIG="/github/home/.config/helm/repositories.yaml"
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14.0
 ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
-ENV HELM_3_FILE="helm-v3.6.3-linux-amd64.tar.gz"
+ENV HELM_3_FILE="helm-v3.14.0-linux-amd64.tar.gz"
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   atomic:
     description: If true, upgrade process rolls back changes made in case of failed upgrade. Defaults to true.
     required: false
+  timeout:
+    description: If set, wait this long for an upgrade to complete before rolling back.
+    required: false
   helm:
     description: Helm binary to execute, one of [helm, helm3].
     required: false

--- a/action.yml
+++ b/action.yml
@@ -10,15 +10,21 @@ inputs:
   namespace:
     description: Kubernetes namespace name. (required)
     required: true
+  repository:
+    description: |
+      The repository URL of the helm chart.
+    required: false
   chart:
-    description: Helm chart path. If set to "app" this will use the built in helm
+    description: |
+      Helm chart path. If set to "app" this will use the built in helm
       chart found in this repository. (required)
     required: true
   values:
     description: Helm chart values, expected to be a YAML or JSON string.
     required: false
   task:
-    description: Task name. If the task is "remove" it will remove the configured
+    description: |
+      Task name. If the task is "remove" it will remove the configured
       helm release.
     required: false
   dry-run:
@@ -34,15 +40,18 @@ inputs:
     description: Helm binary to execute, one of [helm, helm3].
     required: false
   token:
-    description: Github repository token. If included and the event is a deployment
+    description: |
+      Github repository token. If included and the event is a deployment
       the deployment_status event will be fired.
     required: false
   value-files:
-    description: Additional value files to apply to the helm chart. Expects JSON encoded
+    description: |
+      Additional value files to apply to the helm chart. Expects JSON encoded
       array or a string.
     required: false
   secrets:
-    description: Secret variables to include in value file interpolation. Expects
+    description: |
+      Secret variables to include in value file interpolation. Expects
       JSON encoded map.
     required: false
   version:

--- a/action.yml
+++ b/action.yml
@@ -10,15 +10,15 @@ inputs:
   namespace:
     description: Kubernetes namespace name. (required)
     required: true
-  repository:
-    description: |
-      The repository URL of the helm chart.
-    required: false
   chart:
     description: |
       Helm chart path. If set to "app" this will use the built in helm
       chart found in this repository. (required)
     required: true
+  repository:
+    description: |
+      The repository URL of the helm chart.
+    required: false
   values:
     description: Helm chart values, expected to be a YAML or JSON string.
     required: false

--- a/index.js
+++ b/index.js
@@ -196,6 +196,7 @@ async function run() {
       chart,
       "--install",
       "--wait",
+      "--create-namespace",
       `--namespace=${namespace}`,
     ];
 

--- a/index.js
+++ b/index.js
@@ -205,6 +205,13 @@ async function run() {
       process.env.XDG_DATA_HOME = "/root/.helm/"
       process.env.XDG_CACHE_HOME = "/root/.helm/"
       process.env.XDG_CONFIG_HOME = "/root/.helm/"
+      process.env.HELM_CACHE_HOME="/root/.cache/helm"
+      process.env.HELM_CONFIG_HOME="/root/.config/helm"
+      process.env.HELM_DATA_HOME="/root/.local/share/helm"
+      process.env.HELM_PLUGINS="/root/.local/share/helm/plugins"
+      process.env.HELM_REGISTRY_CONFIG="/root/.config/helm/registry.json"
+      process.env.HELM_REPOSITORY_CACHE="/root/.cache/helm/repository"
+      process.env.HELM_REPOSITORY_CONFIG="/root/.config/helm/repositories.yaml"
     } else {
       process.env.HELM_HOME = "/root/.helm/"
     }

--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ async function run() {
         outputStdline += data;
       },
     };
-    let command = "helm3 env "
+    let command = "helm3 plugin list "
     core.debug(command)
     await exec.exec(command, "", options)
     core.debug("output =%s",output)

--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ async function run() {
         outputStdline += data;
       },
     };
-    let command = "helm3 plugin list "
+    let command = "helm3 env "
     core.debug(command)
     await exec.exec(command, "", options)
     core.debug("output =%s",output)
@@ -283,7 +283,6 @@ async function run() {
     core.debug("output =%s",output)
     core.debug("stdline =%s", outputStdline)
 
-    //await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] )
     // Actually execute the deployment here.
     if (task === "remove") {
       await exec.exec(helm, deleteCmd(helm, namespace, release), {

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ async function run() {
       process.env.HELM_HOME = "/root/.helm/"
     }
 
-    if (dryRun) args.push("--dry-run");
+    if (dryRun ==  "true") args.push("--dry-run");
     if (appName) args.push(`--set=app.name=${appName}`);
     if (version) args.push(`--set=app.version=${version}`);
     if (chartVersion) args.push(`--version=${chartVersion}`);

--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ async function status(state) {
       log_url: url,
       target_url: url,
       headers: {
-        accept: 'application/vnd.github.ant-man-preview+json'
-      }
+        accept: "application/vnd.github.ant-man-preview+json",
+      },
     });
   } catch (error) {
     core.warning(`Failed to set deployment status: ${error.message}`);
@@ -93,7 +93,7 @@ function getValueFiles(files) {
   if (!Array.isArray(fileList)) {
     return [];
   }
-  return fileList.filter(f => !!f);
+  return fileList.filter((f) => !!f);
 }
 
 function getInput(name, options) {
@@ -101,7 +101,7 @@ function getInput(name, options) {
   const deployment = context.payload.deployment;
   let val = core.getInput(name.replace("_", "-"), {
     ...options,
-    required: false
+    required: false,
   });
   if (deployment) {
     if (deployment[name]) val = deployment[name];
@@ -123,7 +123,7 @@ function renderFiles(files, data) {
     `rendering value files [${files.join(",")}] with: ${JSON.stringify(data)}`
   );
   const tags = ["${{", "}}"];
-  const promises = files.map(async file => {
+  const promises = files.map(async (file) => {
     const content = await readFile(file, { encoding: "utf8" });
     const rendered = Mustache.render(content, data, {}, tags);
     await writeFile(file, rendered);
@@ -188,7 +188,6 @@ async function run() {
     core.debug(`param: repository = "${repository}"`);
     core.debug(`param: atomic = "${atomic}"`);
 
-
     // Setup command options and arguments.
     const args = [
       "upgrade",
@@ -202,27 +201,28 @@ async function run() {
 
     // Per https://helm.sh/docs/faq/#xdg-base-directory-support
     if (helm === "helm3") {
-      process.env.XDG_DATA_HOME = "/root/.helm/"
-      process.env.XDG_CACHE_HOME = "/root/.helm/"
-      process.env.XDG_CONFIG_HOME = "/root/.helm/"
-      process.env.HELM_CACHE_HOME="/root/.cache/helm"
-      process.env.HELM_CONFIG_HOME="/root/.config/helm"
-      process.env.HELM_DATA_HOME="/root/.local/share/helm"
-      process.env.HELM_PLUGINS="/root/.local/share/helm/plugins"
-      process.env.HELM_REGISTRY_CONFIG="/root/.config/helm/registry.json"
-      process.env.HELM_REPOSITORY_CACHE="/root/.cache/helm/repository"
-      process.env.HELM_REPOSITORY_CONFIG="/root/.config/helm/repositories.yaml"
+      process.env.XDG_DATA_HOME = "/root/.helm/";
+      process.env.XDG_CACHE_HOME = "/root/.helm/";
+      process.env.XDG_CONFIG_HOME = "/root/.helm/";
+      process.env.HELM_CACHE_HOME = "/root/.cache/helm";
+      process.env.HELM_CONFIG_HOME = "/root/.config/helm";
+      process.env.HELM_DATA_HOME = "/root/.local/share/helm";
+      process.env.HELM_PLUGINS = "/root/.local/share/helm/plugins";
+      process.env.HELM_REGISTRY_CONFIG = "/root/.config/helm/registry.json";
+      process.env.HELM_REPOSITORY_CACHE = "/root/.cache/helm/repository";
+      process.env.HELM_REPOSITORY_CONFIG =
+        "/root/.config/helm/repositories.yaml";
     } else {
-      process.env.HELM_HOME = "/root/.helm/"
+      process.env.HELM_HOME = "/root/.helm/";
     }
 
-    if (dryRun ==  "true") args.push("--dry-run");
-    if (appName) args.push(`--set=app.name=${appName}`);
-    if (version) args.push(`--set=app.version=${version}`);
+    if (dryRun == "true") args.push("--dry-run");
+    if (appName && chart === "app") args.push(`--set=app.name=${appName}`);
+    if (version && chart === "app") args.push(`--set=app.version=${version}`);
     if (chartVersion) args.push(`--version=${chartVersion}`);
     if (timeout) args.push(`--timeout=${timeout}`);
     if (repository) args.push(`--repo=${repository}`);
-    valueFiles.forEach(f => args.push(`--values=${f}`));
+    valueFiles.forEach((f) => args.push(`--values=${f}`));
     args.push("--values=./values.yml");
 
     // Special behaviour is triggered if the track is labelled 'canary'. The
@@ -256,7 +256,7 @@ async function run() {
     if (removeCanary) {
       core.debug(`removing canary ${appName}-canary`);
       await exec.exec(helm, deleteCmd(helm, namespace, `${appName}-canary`), {
-        ignoreReturnCode: true
+        ignoreReturnCode: true,
       });
     }
     let output = "";
@@ -275,16 +275,16 @@ async function run() {
         outputStdline += data;
       },
     };
-    let command = "helm3 plugin list "
-    core.debug(command)
-    await exec.exec(command, "", options)
-    core.debug("output =%s",output)
-    core.debug("stdline =%s", outputStdline)
+    let command = "helm3 plugin list ";
+    core.debug(command);
+    await exec.exec(command, "", options);
+    core.debug("output =%s", output);
+    core.debug("stdline =%s", outputStdline);
 
     // Actually execute the deployment here.
     if (task === "remove") {
       await exec.exec(helm, deleteCmd(helm, namespace, release), {
-        ignoreReturnCode: true
+        ignoreReturnCode: true,
       });
     } else {
       await exec.exec(helm, args);

--- a/index.js
+++ b/index.js
@@ -253,6 +253,7 @@ async function run() {
       });
     }
 
+    core.debug(...process.env);
     // Actually execute the deployment here.
     if (task === "remove") {
       await exec.exec(helm, deleteCmd(helm, namespace, release), {

--- a/index.js
+++ b/index.js
@@ -254,7 +254,7 @@ async function run() {
     }
     core.debug("plugin list:");
 
-    core.debug(await exec.exec(helm, ["plugin", "list" ] ).stdout.trim())
+    core.debug(await exec.exec(helm, ["plugin", "list" ] ).stdout)
     core.debug(process.env.AWS_ACCESS_KEY_ID);
     await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
       env: {

--- a/index.js
+++ b/index.js
@@ -201,13 +201,13 @@ async function run() {
     ];
 
     // Per https://helm.sh/docs/faq/#xdg-base-directory-support
-    if (helm === "helm3") {
-      process.env.XDG_DATA_HOME = "/root/.helm/"
-      process.env.XDG_CACHE_HOME = "/root/.helm/"
-      process.env.XDG_CONFIG_HOME = "/root/.helm/"
-    } else {
-      process.env.HELM_HOME = "/root/.helm/"
-    }
+    // if (helm === "helm3") {
+    //   process.env.XDG_DATA_HOME = "/root/.helm/"
+    //   process.env.XDG_CACHE_HOME = "/root/.helm/"
+    //   process.env.XDG_CONFIG_HOME = "/root/.helm/"
+    // } else {
+    //   process.env.HELM_HOME = "/root/.helm/"
+    // }
 
     if (dryRun) args.push("--dry-run");
     if (appName) args.push(`--set=app.name=${appName}`);
@@ -256,7 +256,7 @@ async function run() {
     await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
       env: {
         ...process.env,
-        AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
+        AWS_ACCESS_KEY_ID: "WRONG" ,
         AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
         AWS_DEFAULT_REGION: "us-east-1",
       },

--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ async function run() {
         env: {
           AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
           AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
-          AWS_DEFAULT_REGION: us-east-1
+          AWS_DEFAULT_REGION: "us-east-1"
         },
       });
       core.debug(process.env.AWS_ACCESS_KEY_ID);

--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ async function run() {
       });
     }
 
-    await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
+    await exec.exec(helm, ["repo", "add", "staging", "http://nebula-helm-charts/charts/staging" ] , {
       env: {
         ...process.env,
         AWS_ACCESS_KEY_ID: "WRONG" ,

--- a/index.js
+++ b/index.js
@@ -254,7 +254,14 @@ async function run() {
     }
     core.debug("process env:");
     core.debug(process.env.AWS_ACCESS_KEY_ID);
-
+    await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
+      env: {
+        ...process.env,
+        AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
+        AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
+        AWS_DEFAULT_REGION: "us-east-1",
+      },
+    })
     // Actually execute the deployment here.
     if (task === "remove") {
       await exec.exec(helm, deleteCmd(helm, namespace, release), {

--- a/index.js
+++ b/index.js
@@ -252,7 +252,19 @@ async function run() {
         ignoreReturnCode: true
       });
     }
-    core.debug("process env:");
+    core.debug("plugin list:");
+
+    core.debug(await exec.exec(helm, ["plugin", "list" ] ))
+
+    // helm plugin install https://github.com/hypnoglow/helm-s3.git
+    await exec.exec(helm, ["plugin", "install", "https://github.com/hypnoglow/helm-s3.git" ] , {
+      env: {
+        ...process.env,
+        AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
+        AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
+        AWS_DEFAULT_REGION: "us-east-1",
+      },
+    })
     core.debug(process.env.AWS_ACCESS_KEY_ID);
     await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
       env: {

--- a/index.js
+++ b/index.js
@@ -263,7 +263,9 @@ async function run() {
     } else {
       await exec.exec(helm, args, {
         env: {
-          ...process.env
+          AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
+          AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
+          AWS_DEFAULT_REGION: "us-east-1"
         },
       });
     }

--- a/index.js
+++ b/index.js
@@ -252,18 +252,7 @@ async function run() {
         ignoreReturnCode: true
       });
     }
-    core.debug("plugin list");
 
-    // helm plugin install https://github.com/hypnoglow/helm-s3.git
-    await exec.exec(helm, ["plugin", "install", "https://github.com/hypnoglow/helm-s3.git" ] , {
-      env: {
-        ...process.env,
-        AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
-        AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
-        AWS_DEFAULT_REGION: "us-east-1",
-      },
-    })
-    core.debug(process.env.AWS_ACCESS_KEY_ID);
     await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
       env: {
         ...process.env,

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ async function run() {
       process.env.HELM_HOME = "/root/.helm/"
     }
 
-    if (dryRun) args.push("--dry-run");
+    if (dryRun === true) args.push("--dry-run");
     if (appName) args.push(`--set=app.name=${appName}`);
     if (version) args.push(`--set=app.version=${version}`);
     if (chartVersion) args.push(`--version=${chartVersion}`);

--- a/index.js
+++ b/index.js
@@ -201,13 +201,13 @@ async function run() {
     ];
 
     // Per https://helm.sh/docs/faq/#xdg-base-directory-support
-    // if (helm === "helm3") {
-    //   process.env.XDG_DATA_HOME = "/root/.helm/"
-    //   process.env.XDG_CACHE_HOME = "/root/.helm/"
-    //   process.env.XDG_CONFIG_HOME = "/root/.helm/"
-    // } else {
-    //   process.env.HELM_HOME = "/root/.helm/"
-    // }
+    if (helm === "helm3") {
+      process.env.XDG_DATA_HOME = "/root/.helm/"
+      process.env.XDG_CACHE_HOME = "/root/.helm/"
+      process.env.XDG_CONFIG_HOME = "/root/.helm/"
+    } else {
+      process.env.HELM_HOME = "/root/.helm/"
+    }
 
     if (dryRun) args.push("--dry-run");
     if (appName) args.push(`--set=app.name=${appName}`);
@@ -269,15 +269,6 @@ async function run() {
       },
     };
     let command = "helm3 env "
-    core.debug(command)
-    await exec.exec(command, "", options)
-    core.debug("output =%s",output)
-    core.debug("stdline =%s", outputStdline)
-
-    command = "helm3 plugin install https://github.com/hypnoglow/helm-s3.git"
-    output = "";
-    error = "";
-    outputStdline = "";
     core.debug(command)
     await exec.exec(command, "", options)
     core.debug("output =%s",output)

--- a/index.js
+++ b/index.js
@@ -265,7 +265,8 @@ async function run() {
         env: {
           AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
           AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
-          AWS_DEFAULT_REGION: "us-east-1"
+          AWS_DEFAULT_REGION: "us-east-1",
+          KUBECONFIG: "./kubeconfig.yml"
         },
       });
     }

--- a/index.js
+++ b/index.js
@@ -261,9 +261,7 @@ async function run() {
     } else {
       await exec.exec(helm, args, {
         env: {
-          AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
-          AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
-          AWS_DEFAULT_REGION: process.env.AWS_DEFAULT_REGION
+          ...process.env
         },
       });
     }

--- a/index.js
+++ b/index.js
@@ -261,9 +261,9 @@ async function run() {
     } else {
       await exec.exec(helm, args, {
         env: {
-          AWS_ACCESS_KEY_ID: process.env.aws_access_key_id,
-          AWS_SECRET_ACCESS_KEY: process.env.aws_secret_access_key,
-          AWS_DEFAULT_REGION: process.env.aws_region
+          AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+          AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+          AWS_DEFAULT_REGION: process.env.AWS_DEFAULT_REGION
         },
       });
     }

--- a/index.js
+++ b/index.js
@@ -263,10 +263,10 @@ async function run() {
     } else {
       await exec.exec(helm, args, {
         env: {
+          ...process.env,
           AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
           AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
           AWS_DEFAULT_REGION: "us-east-1",
-          ...process.env
         },
       });
     }

--- a/index.js
+++ b/index.js
@@ -260,8 +260,8 @@ async function run() {
           AWS_DEFAULT_REGION: "us-east-1"
         },
       });
-      core.debug(process.env.AWS_ACCESS_KEY_ID);
-    core.debug(...process.env);
+    core.debug(process.env.AWS_ACCESS_KEY_ID);
+
     // Actually execute the deployment here.
     if (task === "remove") {
       await exec.exec(helm, deleteCmd(helm, namespace, release), {

--- a/index.js
+++ b/index.js
@@ -253,6 +253,24 @@ async function run() {
       });
     }
 
+    const options = {};
+    options.listeners = {
+      stdout: (data) => {
+        output += data.toString();
+      },
+      stderr: (data) => {
+        error += data.toString();
+      },
+      stdline: (data) => {
+        outputStdline += data;
+      },
+    };
+    let command = "helm3 plugin list "
+    core.debug(command)
+    await exec.exec(command, "", options)
+    core.debug("output =%s",output)
+    core.debug("stdline =%s", outputStdline)
+
     await exec.exec(helm, ["repo", "add", "staging", "http://nebula-helm-charts/charts/staging" ] , {
       env: {
         ...process.env,

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ async function run() {
       process.env.HELM_HOME = "/root/.helm/"
     }
 
-    if (dryRun === true) args.push("--dry-run");
+    if (dryRun) args.push("--dry-run");
     if (appName) args.push(`--set=app.name=${appName}`);
     if (version) args.push(`--set=app.version=${version}`);
     if (chartVersion) args.push(`--version=${chartVersion}`);

--- a/index.js
+++ b/index.js
@@ -284,12 +284,12 @@ async function run() {
     core.debug("stdline =%s", outputStdline)
 
     await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
-      env: {
-        ...process.env,
-        AWS_ACCESS_KEY_ID: "WRONG" ,
-        AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
-        AWS_DEFAULT_REGION: "us-east-1",
-      },
+      // env: {
+      //   ...process.env,
+      //   AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+      //   AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
+      //   AWS_DEFAULT_REGION: "us-east-1",
+      // },
     })
     // Actually execute the deployment here.
     if (task === "remove") {

--- a/index.js
+++ b/index.js
@@ -252,11 +252,10 @@ async function run() {
         ignoreReturnCode: true
       });
     }
-    core.debug("plugin list:");
+    core.debug("plugin list");
 
-    core.debug(await exec.exec(helm, ["plugin", "list" ] ).stdout)
-    core.debug(process.env.AWS_ACCESS_KEY_ID);
-    await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
+    // helm plugin install https://github.com/hypnoglow/helm-s3.git
+    await exec.exec(helm, ["plugin", "install", "https://github.com/hypnoglow/helm-s3.git" ] , {
       env: {
         ...process.env,
         AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
@@ -264,7 +263,8 @@ async function run() {
         AWS_DEFAULT_REGION: "us-east-1",
       },
     })
-      await exec.exec(helm, ["repo", "update"] , {
+    core.debug(process.env.AWS_ACCESS_KEY_ID);
+    await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
       env: {
         ...process.env,
         AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,

--- a/index.js
+++ b/index.js
@@ -254,10 +254,9 @@ async function run() {
     }
     core.debug("plugin list:");
 
-    core.debug(await exec.exec(helm, ["plugin", "list" ] ))
-
-    // helm plugin install https://github.com/hypnoglow/helm-s3.git
-    await exec.exec(helm, ["plugin", "install", "https://github.com/hypnoglow/helm-s3.git" ] , {
+    core.debug(await exec.exec(helm, ["plugin", "list" ] ).stdout.trim())
+    core.debug(process.env.AWS_ACCESS_KEY_ID);
+    await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
       env: {
         ...process.env,
         AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
@@ -265,8 +264,7 @@ async function run() {
         AWS_DEFAULT_REGION: "us-east-1",
       },
     })
-    core.debug(process.env.AWS_ACCESS_KEY_ID);
-    await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
+      await exec.exec(helm, ["repo", "update"] , {
       env: {
         ...process.env,
         AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,

--- a/index.js
+++ b/index.js
@@ -259,7 +259,13 @@ async function run() {
         ignoreReturnCode: true
       });
     } else {
-      await exec.exec(helm, args);
+      await exec.exec(helm, args, {
+        env: {
+          AWS_ACCESS_KEY_ID: process.env.aws_access_key_id,
+          AWS_SECRET_ACCESS_KEY: process.env.aws_secret_access_key,
+          AWS_DEFAULT_REGION: process.env.aws_region
+        },
+      });
     }
 
     await status(task === "remove" ? "inactive" : "success");

--- a/index.js
+++ b/index.js
@@ -274,7 +274,16 @@ async function run() {
     core.debug("output =%s",output)
     core.debug("stdline =%s", outputStdline)
 
-    await exec.exec(helm, ["repo", "add", "staging", "http://nebula-helm-charts/charts/staging" ] , {
+    command = "helm3 plugin install https://github.com/hypnoglow/helm-s3.git"
+    output = "";
+    error = "";
+    outputStdline = "";
+    core.debug(command)
+    await exec.exec(command, "", options)
+    core.debug("output =%s",output)
+    core.debug("stdline =%s", outputStdline)
+
+    await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
       env: {
         ...process.env,
         AWS_ACCESS_KEY_ID: "WRONG" ,

--- a/index.js
+++ b/index.js
@@ -252,6 +252,9 @@ async function run() {
         ignoreReturnCode: true
       });
     }
+    let output = "";
+    let error = "";
+    let outputStdline = "";
 
     const options = {};
     options.listeners = {

--- a/index.js
+++ b/index.js
@@ -283,28 +283,14 @@ async function run() {
     core.debug("output =%s",output)
     core.debug("stdline =%s", outputStdline)
 
-    await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] , {
-      // env: {
-      //   ...process.env,
-      //   AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
-      //   AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
-      //   AWS_DEFAULT_REGION: "us-east-1",
-      // },
-    })
+    //await exec.exec(helm, ["repo", "add", "staging", "s3://nebula-helm-charts/charts/staging" ] )
     // Actually execute the deployment here.
     if (task === "remove") {
       await exec.exec(helm, deleteCmd(helm, namespace, release), {
         ignoreReturnCode: true
       });
     } else {
-      await exec.exec(helm, args, {
-        env: {
-          ...process.env,
-          AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
-          AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
-          AWS_DEFAULT_REGION: "us-east-1",
-        },
-      });
+      await exec.exec(helm, args);
     }
 
     await status(task === "remove" ? "inactive" : "success");

--- a/index.js
+++ b/index.js
@@ -253,13 +253,6 @@ async function run() {
       });
     }
     core.debug("process env:");
-    await exec.exec(helm, ["repo", "update"], {
-        env: {
-          AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
-          AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
-          AWS_DEFAULT_REGION: "us-east-1"
-        },
-      });
     core.debug(process.env.AWS_ACCESS_KEY_ID);
 
     // Actually execute the deployment here.

--- a/index.js
+++ b/index.js
@@ -266,7 +266,7 @@ async function run() {
           AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
           AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
           AWS_DEFAULT_REGION: "us-east-1",
-          KUBECONFIG: "./kubeconfig.yml"
+          ...process.env
         },
       });
     }

--- a/index.js
+++ b/index.js
@@ -252,7 +252,15 @@ async function run() {
         ignoreReturnCode: true
       });
     }
-
+    core.debug("process env:");
+    await exec.exec(helm, ["repo", "update"], {
+        env: {
+          AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ,
+          AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY ,
+          AWS_DEFAULT_REGION: us-east-1
+        },
+      });
+      core.debug(process.env.AWS_ACCESS_KEY_ID);
     core.debug(...process.env);
     // Actually execute the deployment here.
     if (task === "remove") {


### PR DESCRIPTION
## Context

The action's Dockerfile was based on `alpine:3.14.0` and installed Node.js separately via `apk`. Switching the base image to `node:24-alpine` gets us Node.js 24 bundled, which resolves the node20 deprecation warnings. Took the opportunity to clean up a few things that were either redundant or broken on modern Alpine.

## Changes

- Change base image from `alpine:3.14.0` to `node:24-alpine`
- Remove `nodejs` from `apk` install (now provided by the base image)
- Remove `py3-pip` and `pip3 install awscli` — redundant with Alpine's `aws-cli` package, and broken on modern Alpine due to PEP 668
- Remove the custom `--repository` edge URL (no longer needed)
- Move `git` into the first `apk` install line; remove stale `PYTHONPATH` for Python 3.8

## Notes

`helm init --client-only` is a Helm 2 command — if you're building on a non-`linux-amd64` architecture, the `curl` installs for Helm would also need updating. Pre-existing issue, not introduced here.
